### PR TITLE
Add dir entry to mime-{en,ja}.texi

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2016-08-14  Erik Hetzner  <egh@e6h.org>
+
+	* mime-en.texi: Add dir entry
+
+	* mime-ja.texi: Likewise
+
 2016-03-12  Kazuhiro Ito  <kzhr@d1.dion.ne.jp>
 
 	* mel.el (mel-prompt-for-encoding): New function.

--- a/mime-en.texi
+++ b/mime-en.texi
@@ -3,6 +3,11 @@
 @setfilename mime-en.info
 @settitle FLIM 1.14 Reference Manual about MIME Features
 @documentencoding iso-2022-jp
+@documentlanguage en
+@dircategory GNU Emacs Lisp
+@direntry
+* FLIM (en): (mime-en).         Internet message library.
+@end direntry
 @titlepage
 @title FLIM 1.14 Reference Manual about MIME Features
 @author MORIOKA Tomohiko <morioka@@jaist.ac.jp>

--- a/mime-ja.texi
+++ b/mime-ja.texi
@@ -4,6 +4,10 @@
 @documentlanguage ja
 @documentencoding iso-2022-jp
 @settitle FLIM 1.14 MIME 機能説明書
+@dircategory GNU Emacs Lisp
+@direntry
+* FLIM (ja): (mime-ja).         Internet message library.
+@end direntry
 @titlepage
 @title FLIM 1.14 MIME 機能説明書
 @author 守岡 知彦 <morioka@@jaist.ac.jp>


### PR DESCRIPTION
This will allow `install-info` to work, which will enable proper installation of the documentation via MELPA.

You can test as follows:

```
makeinfo *.texi 
install-info --dir=dir mime-en.info 
install-info --dir=dir mime-ja.info 
cp dir ~/.emacs.d/elpa/flim-20160311.1537/dir # or wherever you have flim installed as a package
```
