### PR TITLE
Add library flim.el whose name matches that of the package flim

### DIFF
--- a/flim.el
+++ b/flim.el
@@ -1,0 +1,33 @@
+;;; flim.el --- basic message representation and encoding features
+
+;; Copyright (C) 1997-2017  Free Software Foundation, Inc.
+
+;; Keywords: MIME, multimedia, mail, news
+
+;; This file is part of FLIM (Faithful Library about Internet Message).
+
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation; either version 2, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+
+;;; Commentary:
+
+;; FLIM (Faithful Library about Internet Message) provides basic
+;; message representation and encoding features.
+
+;;; Code:
+
+(provide 'flim)
+
+;;; flim.el ends here


### PR DESCRIPTION
A package should always contain a library with the same name.
One benefit of that is that Melpa can then extract the package
description from the library commentary.