### PR TITLE
use ?\s instead of ?(whitespace)

### DIFF
--- a/eword-decode.el
+++ b/eword-decode.el
@@ -582,7 +582,7 @@ such as a version of Net$cape)."
 		      (when (cdr rest) " ")
 		      (cdar rest)
 		      (when (and words
-				 (not (eq (string-to-char (car words)) ? )))
+				 (not (eq (string-to-char (car words)) ?\s)))
 			" "))))
       (when must-unfold
 	(setq word (mapconcat (lambda (chr)

--- a/eword-encode.el
+++ b/eword-encode.el
@@ -151,9 +151,9 @@ MODE is allows `text', `comment', `phrase' or nil.  Default value is
 		     (cons nil mime-header-default-charset-encoding)))
 	    mode)))
        (progn
-	 (setq spacep (memq (aref string 0) '(?  ?\t ?\n)))
+	 (setq spacep (memq (aref string 0) '(?\s ?\t ?\n)))
 	 (while (< i len)
-	   (unless (eq spacep (memq (aref string i) '(?  ?\t ?\n)))
+	   (unless (eq spacep (memq (aref string i) '(?\s ?\t ?\n)))
 	     (setq dest (cons (cons (substring string beg i) spacep) dest))
 	     (setq beg i)
 	     (setq spacep (null spacep)))
@@ -238,7 +238,7 @@ MODE is allows `text', `comment', `phrase' or nil.  Default value is
 		      )
 		 (setq rwl (cdr rwl))
 		 )
-		((memq (aref string 0) '(?  ?\t))
+		((memq (aref string 0) '(?\s ?\t))
 		 (setq string (concat "\n" string)
 		       len (length string)
 		       rwl (cdr rwl))
@@ -316,7 +316,7 @@ MODE is allows `text', `comment', `phrase' or nil.  Default value is
 	    (catch 'success
 	      (while (catch 'found
 		       (while (>= i 0)
-			 (cond ((memq (setq c (aref dest i)) '(?  ?\t))
+			 (cond ((memq (setq c (aref dest i)) '(?\s ?\t))
 				(if (memq i folded-points)
 				    (throw 'found nil)
 				  (setq folded-points (cons i folded-points))

--- a/mel-q-ccl.el
+++ b/mel-q-ccl.el
@@ -153,7 +153,7 @@ abcdefghijklmnopqrstuvwxyz\
           (lambda (r0)
             (cond
              ((= r0 (char-int ?_))
-              `(write-repeat ? ))
+              `(write-repeat ?\s))
              ((= r0 (char-int ?=))
               `((loop
                  (read-branch
@@ -313,7 +313,7 @@ abcdefghijklmnopqrstuvwxyz\
 			       (,(mel-ccl-set-eof-block '((write "Fro") (end)))
 				(read-if (r0 == ?m)
 				  (,(mel-ccl-set-eof-block '((write "From") (end)))
-				   (read-if (r0 == ? )
+				   (read-if (r0 == ?\s)
 				     ((,column = 7)
 				      (,after-wsp = 1)
 				      ,(mel-ccl-set-eof-block '((write "From=20") (end)))
@@ -600,7 +600,7 @@ abcdefghijklmnopqrstuvwxyz\
             (let ((tmp (aref mel-ccl-qp-table r0)))
               (cond
                ((eq tmp 'raw) `(write-read-repeat r0))
-               ((eq tmp 'wsp) (if (eq r0 (char-int ? ))
+               ((eq tmp 'wsp) (if (eq r0 (char-int ?\s))
                                   `(r1 = 1)
                                 `(r1 = 0)))
                ((eq tmp 'cr)
@@ -642,7 +642,7 @@ abcdefghijklmnopqrstuvwxyz\
                 `((read r0)
                   ;; '=' r0
                   (r1 = (r0 == ?\t))
-                  (if ((r0 == ? ) | r1)
+                  (if ((r0 == ?\s) | r1)
                       ;; '=' r0:[\t ]
                       ;; Skip transport-padding.
                       ;; It should check CR LF after
@@ -650,7 +650,7 @@ abcdefghijklmnopqrstuvwxyz\
                       (loop
                        (read-if (r0 == ?\t)
                                 (repeat)
-                                (if (r0 == ? )
+                                (if (r0 == ?\s)
                                     (repeat)
                                   (break)))))
                   ;; '=' [\t ]* r0:[^\t ]

--- a/mel-q.el
+++ b/mel-q.el
@@ -62,7 +62,7 @@
 	   (t
 	    (setq chr (logand (following-char) 255))
 	    (cond
-	     ((and (memq chr '(?  ?\t))	; encode WSP char before CRLF.
+	     ((and (memq chr '(?\s ?\t))	; encode WSP char before CRLF.
 		   (eq (char-after (1+ (point))) ?\n))
 	      (forward-char)
 	      (insert "=\n")
@@ -73,7 +73,7 @@
 		   (eq (char-after (1+  (point))) ?r)
 		   (eq (char-after (+ 2 (point))) ?o)
 		   (eq (char-after (+ 3 (point))) ?m)
-		   (eq (char-after (+ 4 (point))) ? ))
+		   (eq (char-after (+ 4 (point))) ?\s))
 	      (delete-region (point)(1+ (point)))
 	      (insert "=46")		; moved to ?r.
 	      (forward-char 4)		; skip "rom ".
@@ -311,7 +311,7 @@ MODE allows `text', `comment', `phrase' or nil.  Default value is
   (let ((specials (cdr (or (assq mode q-encoding-special-chars-alist)
 			   (assq 'phrase q-encoding-special-chars-alist)))))
     (mapconcat (lambda (chr)
-		 (cond ((eq chr ? ) "_")
+		 (cond ((eq chr ?\s) "_")
 		       ((or (< chr 32) (< 126 chr)
 			    (memq chr specials))
 			(quoted-printable-quote-char chr))

--- a/mel.el
+++ b/mel.el
@@ -340,7 +340,7 @@ Default value is `phrase'."
     (while (< i len)
       (setq chr (aref string i))
       (if (or (Q-encoding-printable-char-p chr mode)
-	      (eq chr ? ))
+	      (eq chr ?\s))
 	  (setq l (+ l 1))
 	(setq l (+ l 3)))
       (setq i (+ i 1)))

--- a/mime-conf.el
+++ b/mime-conf.el
@@ -89,7 +89,7 @@
 (defsubst mime-mailcap-look-at-schar ()
   (let ((chr (following-char)))
     (if (and chr
-	     (>= chr ? )
+	     (>= chr ?\s)
 	     (/= chr ?\;)
 	     (/= chr ?\\)
 	     )

--- a/smtp.el
+++ b/smtp.el
@@ -736,11 +736,11 @@ BUFFER may be a buffer or a buffer name which contains mail message."
 	  (erase-buffer)
 	  (insert " " simple-address-list "\n")
 	  ;; newline --> blank
-	  (subst-char-in-region (point-min) (point-max) 10 ?  t)
+	  (subst-char-in-region (point-min) (point-max) 10 ?\s t)
 	  ;; comma   --> blank
-	  (subst-char-in-region (point-min) (point-max) ?, ?  t)
+	  (subst-char-in-region (point-min) (point-max) ?, ?\s t)
 	  ;; tab     --> blank
-	  (subst-char-in-region (point-min) (point-max)	 9 ?  t)
+	  (subst-char-in-region (point-min) (point-max)	 9 ?\s t)
 
 	  (goto-char (point-min))
 	  ;; tidyness in case hook is not robust when it looks at this

--- a/std11.el
+++ b/std11.el
@@ -418,7 +418,7 @@ be the result."
   :type '(repeat function))
 
 (eval-and-compile
-  (defconst std11-space-char-list '(?  ?\t ?\n))
+  (defconst std11-space-char-list '(?\s ?\t ?\n))
   (defconst std11-special-char-list '(?\] ?\[
 					  ?\( ?\) ?< ?> ?@
 					  ?, ?\; ?: ?\\ ?\"


### PR DESCRIPTION
`? ` and `?\ ` and `?\s` are return same value.
`?\s` is easier to read and understand.

```emacs-lisp
(list ?  ?\  ?\s)
;;=> (32 32 32)
```
ref: https://www.gnu.org/software/emacs/manual/html_mono/elisp.html#Basic-Char-Syntax